### PR TITLE
Improve robustness: Kafka retry in automatic-generator; redirect / ->…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.bak
+__pycache__/

--- a/automatic-generator/main.py
+++ b/automatic-generator/main.py
@@ -1,31 +1,44 @@
 from kafka import KafkaProducer
+from kafka.errors import NoBrokersAvailable, KafkaTimeoutError, KafkaError
 import json
 import time
 from datetime import datetime
 import random
 
-producer = KafkaProducer(
-    bootstrap_servers='kafka:9092',
-    value_serializer=lambda v: json.dumps(v).encode('utf-8')
-)
+def connect_producer():
+    while True:
+        try:
+            producer = KafkaProducer(
+                bootstrap_servers='kafka:9092',
+                value_serializer=lambda v: json.dumps(v).encode('utf-8')
+            )
+            print("[INFO] Conectado a Kafka (automatic-generator)")
+            return producer
+        except NoBrokersAvailable:
+            print("[WARN] Kafka no disponible, reintentando en 5 segundos...")
+            time.sleep(5)
 
-actions = ['login', 'purchase', 'logout', 'click', 'view']
+def main():
+    actions = ['login', 'purchase', 'logout', 'click', 'view']
+    producer = connect_producer()
+    print("[INFO] Iniciando generación automática de eventos cada 2 segundos...")
 
-print("[INFO] Iniciando generación automática de eventos cada 2 segundos...")
+    while True:
+        event = {
+            "user": f"user_auto_{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}",
+            "action": random.choice(actions),
+            "timestamp": datetime.utcnow().isoformat()
+        }
+        try:
+            producer.send("events", event)
+            producer.flush()
+            print(f"[GENERADO] {event}")
+        except (KafkaTimeoutError, KafkaError) as e:
+            print(f"[ERROR] Kafka error: {e}. Reintentando conexión...")
+            producer = connect_producer()
+            continue
 
-while True:
-    action = random.choice(actions)
-    timestamp = datetime.utcnow().isoformat()
-    user = f"user_auto_{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}"
+        time.sleep(2)
 
-    event = {
-        "user": user,
-        "action": action,
-        "timestamp": timestamp
-    }
-
-    producer.send("events", event)
-    producer.flush()
-    print(f"[GENERADO] {event}")
-
-    time.sleep(2)
+if __name__ == "__main__":
+    main()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,63 @@
+services:
+  zookeeper:
+    healthcheck:
+      test: ["CMD-SHELL","bash -lc '</dev/tcp/127.0.0.1/2181'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    volumes:
+      - zookeeper-data:/var/lib/zookeeper/data
+      - zookeeper-log:/var/lib/zookeeper/log
+
+  kafka:
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL","bash -lc '</dev/tcp/127.0.0.1/9092'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+
+  redis:
+    healthcheck:
+      test: ["CMD","redis-cli","ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    volumes:
+      - redis-data:/data
+    command: ["redis-server","--appendonly","yes","--save","60","1000","--maxmemory","256mb","--maxmemory-policy","allkeys-lru"]
+
+  event-generator:
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+  event-consumer:
+    depends_on:
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  event-viewer:
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  automatic-generator:
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+volumes:
+  zookeeper-data:
+  zookeeper-log:
+  kafka-data:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   zookeeper:

--- a/event-viewer/main.py
+++ b/event-viewer/main.py
@@ -4,6 +4,12 @@ import json
 
 app = Flask(__name__)
 
+from flask import redirect
+
+@app.route('/')
+def index():
+    return redirect('/events', code=302)
+
 # Conexión a Redis
 r = redis.Redis(host='redis', port=6379)
 


### PR DESCRIPTION
- Add retry loop in automatic-generator (handles NoBrokersAvailable on boot and transient Kafka errors).
- Redirect / -> /events in viewer to avoid 404 at root.
- Provide docker-compose.override.yml with:
  - healthchecks + depends_on: condition: service_healthy
  - persisted volumes for ZooKeeper/Kafka/Redis
  - Redis AOF enabled + memory limit (256MB, allkeys-lru)
- Remove obsolete 'version:' key in compose file (Compose v2).

Testing:
- Fresh VM: services healthy, viewer en / (redirect) y /events.
- Reboot host: auto-recovery; automatic-generator estable.
